### PR TITLE
Use Docker Compose to run application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,9 +2,9 @@
 .pydevproject
 __pycache__
 /static/
-*.pyc
-*.pid
-*.sock
+**/*.pyc
+**/*.pid
+**/*.sock
 /media
 /bin/
 /lib/
@@ -14,12 +14,11 @@ django_app_nginx.conf
 /media/
 /.idea/*
 /app/build/*
-*.iml
+**/*.iml
 /log/*
 django_auth_app/migrations/0*
 sundog/migrations/0*
-local_config.py
 import/history/*
 
-# Docker service persistent data:
-/data/
+# Docker service data
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM django:onbuild
+
+COPY local_config_docker.py local_config.py
+RUN mkdir -p log && touch log/django.log log/sundog.log
+RUN python manage.py makemigrations
+
+CMD \
+  python manage.py migrate && \
+  echo "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@example.com', 'admin')" | python manage.py shell && \
+  gunicorn --bind=0.0.0.0:80 sundog.wsgi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "2"
+
+services:
+
+  web:
+    build: .
+    expose:
+      - "80"
+    links:
+      - sundog_db
+      - elasticsearch
+    environment:
+      DEBUG: 'true'
+    restart: always
+
+  elasticsearch:
+    image: elasticsearch
+    volumes:
+      - "./data/elasticsearch/data:/usr/share/elasticsearch/data"
+      - "./data/elasticsearch/log:/usr/share/elasticsearch/log"
+
+  sundog_db:
+    image: postgres
+    environment:
+      POSTGRES_DB: "sundog_db"
+      POSTGRES_USER: "sundog_db"
+      POSTGRES_PASSWORD: "sundog_db"
+    volumes:
+      - "./data/postgres/data:/var/lib/postgresql/data"
+      - "./data/postgres/log:/var/log/postgresql"

--- a/local_config_docker.py
+++ b/local_config_docker.py
@@ -1,0 +1,19 @@
+# Apparently unused options for django.contrib.sites:
+SITE_DOMAIN = ''
+SITE_HOST = ''
+HOST = 'localhost'
+
+# Disabled if running in debugging mode, so this is probably not important for now:
+ALLOWED_HOSTS = []
+
+DEBUG = True
+
+# Secrets:
+ADDRESS_API_KEY = ''
+
+# Database connection setup:
+DATABASE_HOST = 'sundog_db'
+DATABASE_PORT = '5432'
+DATABASE_NAME = 'sundog_db'
+DATABASE_USER = 'sundog_db'
+DATABASE_PASSWORD = 'sundog_db'

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ brotlipy==0.5.1
 whitenoise==3.2.1
 django-colorful==1.2
 chardet==2.3.0
+gunicorn==19.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ django-colorfield==0.1.10
 django-multi-email-field==0.4
 brotlipy==0.5.1
 whitenoise==3.2.1
+django-colorful==1.2
+chardet==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ mock==2.0.0
 django-allauth
 django-colorfield==0.1.10
 django-multi-email-field==0.4
+brotlipy==0.5.1
+whitenoise==3.2.1

--- a/settings.py
+++ b/settings.py
@@ -81,6 +81,8 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
 
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
     'sundog.middleware.TimezoneMiddleware',
@@ -291,3 +293,5 @@ CRONJOBS = [
 SEED_FILE_ID = 1
 
 SHORT_DATETIME_FORMAT = 'm/d/Y h:i a'
+
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'


### PR DESCRIPTION
This simplifies application execution through Docker and Docker Compose.  The provided `Dockerfile` builds an image for the Django application, and the `docker-compose.yml` file specifies how to execute the built application image along with local instances of PostgreSQL and Elasticsearch for development.

A static file serving library for WSGI applications, [WhiteNoise](http://whitenoise.evans.io/), was added to the application, and the Docker setup executes it not through NGINX, but through Gunicorn, which greatly simplifies bringing up the application.

In principle, no changes were made that would break existing workflows based on NGINX.  Please test, though; no attempt was made to execute the application with the added WhiteNoise middleware.
