### PR TITLE
Use mgomezch/local_services devpi for dev builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y \
   sqlite3 \
   --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
+ARG PIP_INDEX_URL
+ARG PIP_TRUSTED_HOST
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -4,6 +4,13 @@ version: "2"
 services:
 
   web:
+    build:
+      args:
+        # FIXME: These should be the args used, but until Docker 1.13 is released with the enhancement at <https://github.com/docker/docker/pull/27702>, the build container cannot talk to the local-services IPs, as it won’t be on the same network.  Once that enhancement gets released, there should be a way to specify the network used for the build container here in Compose, perhaps with a `network` key within the `build` section.  For now, wire the Docker host IP address, as the port is published there anyway.
+        PIP_INDEX_URL: "http://172.17.0.1:3141/root/pypi/+simple/"
+        PIP_TRUSTED_HOST: "172.17.0.1"
+        # PIP_INDEX_URL: "http://devpi-local-3141.service.consul.test:3141/simple/"
+        # PIP_TRUSTED_HOST: "devpi-local-3141.service.consul.test:3141"
     logging:
       driver: "gelf"
       options:


### PR DESCRIPTION
This greatly reduces build time on slow networks for the Docker image layer that installs pip requirements by fetching packages from a local PyPi pull-through cache running through the Docker Compose services setup in mgomezch/local_services.

This will only be in effect if `docker-compose.development.yml` is symlinked as `docker-compose.override.yml`; otherwise, it will always fetch directly from PyPi.
