### PR TITLE
Implement per-column datatable search fields

### DIFF
--- a/sundog/components/contacts/views.py
+++ b/sundog/components/contacts/views.py
@@ -6,7 +6,6 @@ from datatableview.columns import (
     TextColumn,
 )
 from datatableview.helpers import through_filter
-from datatableview.views import XEditableDatatableView
 from django.contrib.auth.decorators import login_required
 from django.http import Http404
 from django.shortcuts import redirect
@@ -17,7 +16,7 @@ from settings import SHORT_DATETIME_FORMAT
 from sundog.middleware import Responder
 from sundog.models import Contact
 from sundog.routing import decorate_view, route
-from sundog.utils import const
+from sundog.utils import SundogDatatableView, const
 
 
 @route(r'^contacts/?$', name='contacts.list')
@@ -25,7 +24,7 @@ from sundog.utils import const
 @route(r'^contacts/lists/$', name='new_list')  # FIXME: Create proper view
 @route(r'^dataSources/$', name='data_sources')  # FIXME: Create proper view
 @decorate_view(login_required)
-class ContactsList(XEditableDatatableView):
+class ContactsList(SundogDatatableView):
     template_name = 'sundog/contacts/list.html'
 
     model = Contact
@@ -36,6 +35,21 @@ class ContactsList(XEditableDatatableView):
     }
 
     default_list = 'my_contacts'
+
+    searchable_columns = [
+        'type_',
+        'created_at',
+        'company',
+        'assigned_to',
+        'full_name',
+        'phone_number',
+        'email',
+        'stage',
+        'status',
+        'data_source',
+        'last_call_activity',
+        'time_in_status',
+    ]
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -169,6 +183,8 @@ class ContactsList(XEditableDatatableView):
                 'time_in_status',
                 'actions',
             ]
+
+            footer = True
 
             ordering = [
                 '-created_at',

--- a/sundog/static/css/custom.css
+++ b/sundog/static/css/custom.css
@@ -61,6 +61,26 @@ ul.dropdown-menu li a{
   margin: 0;
 }
 
+/* Increase table action glyph icon button size */
+.table-action.glyphicon {
+  font-size: 200%
+}
+
+/* Move datatable footer with search controls to top of table, under header */
+.datatable tfoot {
+    display: table-header-group;
+}
+
+/* Make per-column search inputs adapt to the column width */
+.datatable-search-input {
+    width: 100%;
+}
+
+/* Reduce font size for tables implemented with datatables.js */
+table.datatable {
+    font-size: smaller;
+}
+
 /* Admin custom style */
 .action-checkbox, .action-checkbox-column{
     padding: 5px;

--- a/sundog/templates/base.html
+++ b/sundog/templates/base.html
@@ -21,9 +21,28 @@
       <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s=" crossorigin="anonymous"></script>
 
       {# datatables.js #}
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.12/css/dataTables.bootstrap.min.css" integrity="sha256-7MXHrlaY+rYR1p4jeLI23tgiUamQVym2FWmiUjksFDc=" crossorigin="anonymous">
-      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.12/js/jquery.dataTables.min.js" integrity="sha256-TX6POJQ2u5/aJmHTJ/XUL5vWCbuOw0AQdgUEzk4vYMc=" crossorigin="anonymous"></script>
-      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.12/js/dataTables.bootstrap.min.js" integrity="sha256-90YqnHom4j8OhcEQgyUI2IhmGYTBO54Adcf3YDZU9xM=" crossorigin="anonymous"></script>
+      <link rel="stylesheet" href="https://cdn.datatables.net/1.10.12/css/dataTables.bootstrap.min.css" integrity="sha384-p/NQoT0G1WaSOtpkNLDWe2nWstNl65yswLy5523OUNaS0Zg+2Pw+6P2OID9vA74O" crossorigin="anonymous">
+      <script src="https://cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js" integrity="sha384-89aj/hOsfOyfD0Ll+7f2dobA15hDyiNb8m1dJ+rJuqgrGR+PVqNU8pybx4pbF3Cc" crossorigin="anonymous"></script>
+      <script src="https://cdn.datatables.net/1.10.12/js/dataTables.bootstrap.min.js" integrity="sha384-SR1gffNfWzqensZ3u8O8AkytPBwtg4pKQuOrHUvvCuAxqcoAE4LWPryg4o+1Y9uP" crossorigin="anonymous"></script>
+
+      {# datatables.js Buttons extension; column visibility controls #}
+      <link rel="stylesheet" href="https://cdn.datatables.net/buttons/1.2.2/css/buttons.bootstrap.min.css" integrity="sha384-58v0/SFV4XyV7kvmd3VbZiRCnhEtNGCl71D+RMMVFerC/EA4LEu+M4cANIovKzoJ" crossorigin="anonymous">
+      <link rel="stylesheet" href="https://cdn.datatables.net/buttons/1.2.2/css/buttons.dataTables.min.css" integrity="sha384-QDuPH5mj+mpSlxOMdoDh7QVS2FWsvwk7xLb8FlISOJG5V75v8rmHEjn65broLs2a" crossorigin="anonymous"><Paste>
+      <script src="https://cdn.datatables.net/buttons/1.2.2/js/dataTables.buttons.min.js" integrity="sha384-NkSiSC/tdDtrg3G0BRZzKfm0FP4FKBW6jBEa0x3nRjTcOuttMFt9Kt66ZnBwyz7r" crossorigin="anonymous"></script>
+      <script src="https://cdn.datatables.net/buttons/1.2.2/js/buttons.colVis.min.js" integrity="sha384-cL8BKX3Gk1q5L71YJAGVdP7L0noPN90puPBBOhSbDaeWLhucDxRXYx2tfThCcpbY" crossorigin="anonymous"></script>
+
+      {# datatables.js ColReorder extension #}
+      <link rel="stylesheet" href="https://cdn.datatables.net/colreorder/1.3.2/css/colReorder.bootstrap.min.css" integrity="sha384-bWGwwpUunpw917+yCbCsXbFXHofH4CiN+f3NLCJcYMu+3Zv1AgDGVXUGXI0EIFgF" crossorigin="anonymous">
+      <script src="https://cdn.datatables.net/colreorder/1.3.2/js/dataTables.colReorder.min.js" integrity="sha384-8sKIxe0MxXanTEDqgeFTtwr/DWqio79X5LQLGmQfdZ3ZZdNkmUB+ss+x24nrzOfZ" crossorigin="anonymous"></script>
+
+      {# datatables.js FixedHeader extension #}
+      <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/3.1.2/css/fixedHeader.bootstrap.min.css" integrity="sha384-WCvWgurF5s3iQOhbC89lPn7E9F0QnmdzbG4MOluQuDFxCarl/3LXKgCeQKvjf+dF" crossorigin="anonymous">
+      <script src="https://cdn.datatables.net/fixedheader/3.1.2/js/dataTables.fixedHeader.min.js" integrity="sha384-McNNqs4QPnl7yrdc/xx7b1z6m7qw97kz61X1li5yNChyv9cIhPLh24nB49YRVHZH" crossorigin="anonymous"></script>
+
+      {# datatables.js Responsive extension #}
+      <link rel="stylesheet" href="https://cdn.datatables.net/responsive/2.1.0/css/responsive.bootstrap.min.css" integrity="sha384-mYr5nM15bzbRc/YAHE3sIufX4kiYl16TXND5OqoCr+k66ba4GZ8uvUGtFh8A2NnQ" crossorigin="anonymous">
+      <script src="https://cdn.datatables.net/responsive/2.1.0/js/dataTables.responsive.min.js" integrity="sha384-VPEdSQrwo2+kA/WW4V5bP9Vyi1UamWp5zcxop+N1gQgZj2en3sR7efLLjU0PDgmU" crossorigin="anonymous"></script>
+      <script src="https://cdn.datatables.net/responsive/2.1.0/js/responsive.bootstrap.min.js" integrity="sha384-N5UU3xS/wQK8Y0MWso1OEsFa3GbImeRX+cpwgjnG7AOM1ZqMXGrEp3sc83aCzHmT" crossorigin="anonymous"></script>
 
       {# Bootstrap #}
       <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">

--- a/sundog/templates/sundog/base/table.html
+++ b/sundog/templates/sundog/base/table.html
@@ -16,16 +16,112 @@
   {# datatableview #}
   <script type="text/javascript" src="{% static "js/datatableview.min.js" %}"></script>
 
-  {# Initialization for x-editable tables #}
+  {# Initialization for datatables #}
   <script type="text/javascript">
+
       $.fn.editable.defaults.mode = 'inline';
       datatableview.auto_initialize = false;
+
       $(function() {
-        var xeditable_options = {};
-        datatableview.initialize($('.datatable'), {
-          fnRowCallback: datatableview.make_xeditable(xeditable_options),
+
+        {% comment %}
+        Enable flexible table width; see
+        https://datatables.net/examples/basic_init/flexible_width.html
+        {% endcomment %}
+        $('table.datatable').attr('width', '100%');
+
+        var datatable = datatableview.initialize($('.datatable'), {
+
+          {# Column visibility control button #}
+          buttons: [
+            'colvis',
+          ],
+
+          {% comment %}
+          This is the default Bootstrap layout but adds the buttons extension
+          B control character to the initial row.  See
+          https://datatables.net/reference/option/dom
+          {% endcomment %}
+          dom: (
+            "<'row'<'col-sm-6'Bl><'col-sm-6'f>>" +
+            "<'row'<'col-sm-12'tr>>" +
+            "<'row'<'col-sm-5'i><'col-sm-7'p>>"
+          ),
+
+          {% comment %}
+          x-editable columns initialization options; see
+          http://django-datatable-view.appspot.com/x-editable-columns/
+          {% endcomment %}
+          fnRowCallback: datatableview.make_xeditable({
+            {% block table_view_xeditable_options %}
+            {% endblock table_view_xeditable_options %}
+          }),
+
+          {% comment %}
+          Enable the Responsive extension; see
+          https://datatables.net/extensions/responsive/
+          {% endcomment %}
+          responsive: true,
+
+          {# Insert additional datatable options in derived templates #}
+          {% block table_view_datatable_options %}
+          {% endblock table_view_datatable_options %}
+
         });
+
+        {% comment %}
+        Substitute datatable column footer contents with a text input box for
+        colum-specific filtering for columns with the data-config-searchable
+        attribute set to true.  Other footer cells are left empty.
+        {% endcomment %}
+        $('.datatable thead th').each(
+          function() {
+            $('.datatable tfoot th').eq($(this).index()).html(
+              !$(this).data('config-searchable')
+              ? ''
+              : (
+                '<input' +
+                  ' type="text"' +
+                  ' class="datatable-search-input"' +
+                  ' data-column-name="' + $(this).data('name') + '"' +
+                  ' placeholder="Search"' +
+                ' />'
+              )
+            );
+          }
+        );
+
+        {% comment %}
+        Implement per-column filtering using the datatables search API; see
+        https://datatables.net/reference/api/search()
+        {% endcomment %}
+        datatable.api().columns().every(
+          function() {
+            var column = this;
+            $(
+              'input.datatable-search-input',
+              column.footer()
+            ).on(
+              'keyup change',
+              function() {
+                if (column.search() !== this.value) {
+                  column.search(this.value).draw();
+                }
+              }
+            )
+          }
+        )
+
+        {% comment %}
+        Insert additional JavaScript code in derived templates for datatable
+        initialization.  Note that inserted scripts will have access to local
+        variables, including the datatable instance.
+        {% endcomment %}
+        {% block table_view_initialization %}
+        {% endblock table_view_initialization %}
+
       });
+
   </script>
 
   {% block table_view_head %}

--- a/sundog/templates/sundog/contacts/list/actions.html
+++ b/sundog/templates/sundog/contacts/list/actions.html
@@ -1,23 +1,27 @@
-<a
-  id="{{ contact_id }}-edit-contact-status"
-  href="{% url 'edit_contact_status' contact_id=contact_id %}"
-  class="edit-contact-status"
->
-  <span title="Edit Status" class="glyphicon glyphicon-th"></span>
-</a>
+<span class="text-nowrap">
 
-<a
-  id="{{ contact_id }}-edit-contact-info"
-  href="{% url 'edit_contact' contact_id=contact_id %}"
-  class="edit-contact-info"
->
-  <span title="Edit Info" class="glyphicon glyphicon-edit"></span>
-</a>
+  <a
+    id="{{ contact_id }}-edit-contact-status"
+    href="{% url "edit_contact_status" contact_id=contact_id %}"
+    class="edit-contact-status"
+  >
+    <span title="Edit Status" class="table-action glyphicon glyphicon-th"></span>
+  </a>
 
-<a
-  id="{{ contact_id }}-contact-dashboard"
-  href="{% url 'contact_dashboard' contact_id=contact_id %}"
-  class="contact-dashboard"
->
-  <span title="Dashboard" class="glyphicon glyphicon-arrow-right"></span>
-</a>
+  <a
+    id="{{ contact_id }}-edit-contact-info"
+    href="{% url "edit_contact" contact_id=contact_id %}"
+    class="edit-contact-info"
+  >
+    <span title="Edit Info" class="table-action glyphicon glyphicon-edit"></span>
+  </a>
+
+  <a
+    id="{{ contact_id }}-contact-dashboard"
+    href="{% url "contact_dashboard" contact_id=contact_id %}"
+    class="contact-dashboard"
+  >
+    <span title="Dashboard" class="table-action glyphicon glyphicon-arrow-right"></span>
+  </a>
+
+</span>

--- a/sundog/templates/sundog/documents/list/actions.html
+++ b/sundog/templates/sundog/documents/list/actions.html
@@ -1,19 +1,23 @@
-<a
-  class="fm-delete documents-delete"
-  data-fm-callback="reload"
-  data-fm-head="Delete this document?  {{ document_title }}"
-  href="{% url 'documents.delete.ajax' pk=document_id %}"
-  id="{{ document_id }}-delete-document"
->
-  <span title="Delete document" class="glyphicon glyphicon-remove"></span>
-</a>
+<span class="text-nowrap">
 
-<a
-  class="fm-update documents-edit"
-  data-fm-callback="reload"
-  data-fm-head="Editing document: {{ document_title }}"
-  href="{% url 'documents.edit.ajax' pk=document_id %}"
-  id="{{ document_id }}-edit-document"
->
-  <span title="Edit document" class="glyphicon glyphicon-arrow-right"></span>
-</a>
+  <a
+    class="documents-delete fm-delete"
+    data-fm-callback="reload"
+    data-fm-head="Delete this document?  {{ document_title }}"
+    href="{% url "documents.delete.ajax" pk=document_id %}"
+    id="{{ document_id }}-delete-document"
+  >
+    <span title="Delete document" class="table-action glyphicon glyphicon-remove"></span>
+  </a>
+
+  <a
+    class="documents-edit fm-update"
+    data-fm-callback="reload"
+    data-fm-head="Editing document: {{ document_title }}"
+    href="{% url "documents.edit.ajax" pk=document_id %}"
+    id="{{ document_id }}-edit-document"
+  >
+    <span title="Edit document" class="table-action glyphicon glyphicon-arrow-right"></span>
+  </a>
+
+</span>


### PR DESCRIPTION
This should help implement the required filters for the main listing in the settlements tab.

This is what it looks like on the contacts listing:
![image](https://cloud.githubusercontent.com/assets/774845/20651835/2573755a-b4c3-11e6-8c4b-aacc8dd533e8.png)

To use it, simply make your datatable view a subclass of `sundog.utils.SundogDatatableView` and specify the names of the columns that should provide a search input box in the `searchable_columns` class attribute; e.g.:

```
class SomeList(SundogDatatableView):
    searchable_columns = [
        'created_at',
        'company',
    ]

    …
```

More complex search input behavior, such as autocompletion, could be implemented client-side.  The view searches by adding conditions to the model queryset over the column fields, but this has not been tested for foreign key fields.